### PR TITLE
feat:Change 'go generate' to be opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ on:
         description: "Skip running go generate if needed."
         required: false
         type: boolean
-        default: false
+        default: true
       go-generate-deps:
         description: "The line sparated list of go generate dependencies to install via `go install` prior to running `go generate`."
         required: false


### PR DESCRIPTION
BREAKING CHANGE

This change changes the default from an "opt-out" to "opt-in".  The reason for this change is that by running 'go generate ./...' before building/testing, in most cases it is masking a larger problem where the files in the repo are not in the correct state.