### PR TITLE
Add multi arch docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -893,7 +893,7 @@ jobs:
         shell: bash
         run: |
           # check for config-breaking set if input params
-          if [[ ("${{ inputs.release-arch-arm64 }}" == "false" ) && ("${{ inputs.release-arch-arm64  == "false")" ]]; then
+          if [[ ("${{ inputs.release-arch-arm64 }}" == "false" ) && ("${{ inputs.release-arch-arm64 }} == "false")" ]]; then
             echo "error condition: release-docker must include either release-arch-arm64/amd64, both are false"
             exit -1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -851,18 +851,18 @@ jobs:
           gecho "      - \"--build-arg=ARCH=arm64\""
           gecho "      - \"--build-arg=PLATFORM=linux/arm64v8\""
           gecho "    image_templates:"
-          gecho "      - ghcr.io/${{ github.repository }}-arm64:{{ .Tag }}"
+          gecho "      - ghcr.io/${{ github.repository }}:{{ .Tag }}-arm64"
 
           if [[ "${{ inputs.release-docker-major }}" == "true" ]]; then
-          gecho "      - ghcr.io/${{ github.repository }}-arm64:v{{ .Major }}"
+          gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }-arm64}"
           fi
 
           if [[ "${{ inputs.release-docker-minor }}" == "true" ]]; then
-          gecho "      - ghcr.io/${{ github.repository }}-arm64:v{{ .Major }}.{{ .Minor }}"
+          gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}.{{ .Minor }}-arm64"
           fi
 
           if [[ "${{ inputs.release-docker-latest }}" == "true" ]]; then
-          gecho "      - ghcr.io/${{ github.repository }}-arm64:latest"
+          gecho "      - ghcr.io/${{ github.repository }}:latest-arm64"
           fi
 
           if [[ "${{ inputs.release-skip-publish }}" == "--skip-publish" ]]; then
@@ -900,10 +900,10 @@ jobs:
           gecho "  - name_template: ghcr.io/${{ github.repository }}:{{ .Tag }}"
           gecho "    image_templates:"
           if [[ "${{ inputs.release-arch-amd64 }}" == "true" ]]; then
-            gecho "      -  ghcr.io/${{ github.repository }}-amd64:{{ .Tag }}"
+            gecho "      -  ghcr.io/${{ github.repository }}:{{ .Tag }}-amd64"
           fi
           if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
-            gecho "      -  ghcr.io/${{ github.repository }}-arm64:{{ .Tag }}"
+            gecho "      -  ghcr.io/${{ github.repository }}:{{ .Tag }-arm64}"
           fi
 
       - name: Determine project license(s)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -893,7 +893,7 @@ jobs:
         shell: bash
         run: |
           # check for config-breaking set if input params
-          if [[ (${{ inputs.release-arch-arm64 }} == "false" ) && (${{ inputs.release-arch-arm64  == "false") ]]; then
+          if [[ ("${{ inputs.release-arch-arm64 }}" == "false" ) && ("${{ inputs.release-arch-arm64  == "false")" ]]; then
             echo "error condition: release-docker must include either release-arch-arm64/amd64, both are false"
             exit -1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -893,7 +893,7 @@ jobs:
         shell: bash
         run: |
           # check for config-breaking set if input params
-          if [[ ("${{ inputs.release-arch-arm64 }}" == "false" ) && ("${{ inputs.release-arch-arm64 }} == "false")" ]]; then
+          if [[ ("${{ inputs.release-arch-arm64 }}" == "false" ) && ("${{ inputs.release-arch-arm64 }}" == "false") ]]; then
             echo "error condition: release-docker must include either release-arch-arm64/amd64, both are false"
             exit -1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -797,18 +797,18 @@ jobs:
           gecho "      - \"--build-arg=ARCH=amd64\""
           gecho "      - \"--build-arg=PLATFORM=linux/amd64\""
           gecho "    image_templates:"
-          gecho "      - ghcr.io/${{ github.repository }}:{{ .Tag }}"
+          gecho "      - ghcr.io/${{ github.repository }}:{{ .Tag }-amd64}"
 
           if [[ "${{ inputs.release-docker-major }}" == "true" ]]; then
-          gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}"
+          gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}-amd64"
           fi
 
           if [[ "${{ inputs.release-docker-minor }}" == "true" ]]; then
-          gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}.{{ .Minor }}"
+          gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}.{{ .Minor }}-amd64"
           fi
 
           if [[ "${{ inputs.release-docker-latest }}" == "true" ]]; then
-          gecho "      - ghcr.io/${{ github.repository }}:latest"
+          gecho "      - ghcr.io/${{ github.repository }}:latest-amd64"
           fi
 
           if [[ "${{ inputs.release-skip-publish }}" == "--skip-publish" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -881,6 +881,31 @@ jobs:
           fi
           gecho ""
 
+      - name: Generate the docker manifest
+        if: |
+          inputs.release-custom-file == false     &&
+          inputs.release-type        == 'program' &&
+          inputs.release-docker      == true
+        working-directory: ${{ inputs.working-directory }}
+        shell: bash
+        run: |
+          # check for config-breaking set if input params
+          if [[ (${{ inputs.release-arch-arm64 }} == "false" ) && (${{ inputs.release-arch-arm64  == "false") ]]; then
+            echo "error condition: release-docker must include either release-arch-arm64 and/or arm64, both are false"
+            exit -1
+          fi
+
+          gecho() { echo "$1" >> .goreleaser.yml ; }
+          gecho "docker_manifests:"
+          gecho "  - name_template: ghcr.io/${{ github.repository }}:{{ .Tag }}"
+          gecho "    image_templates:"
+          if [[ "${{ inputs.release-arch-amd64 }}" == "true" ]]; then
+            gecho "      -  ghcr.io/${{ github.repository }}-amd64:{{ .Tag }}"
+          fi
+          if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
+            gecho "      -  ghcr.io/${{ github.repository }}-arm64:{{ .Tag }}"
+          fi
+
       - name: Determine project license(s)
         if: |
           inputs.release-custom-file == false     &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -891,7 +891,7 @@ jobs:
         run: |
           # check for config-breaking set if input params
           if [[ (${{ inputs.release-arch-arm64 }} == "false" ) && (${{ inputs.release-arch-arm64  == "false") ]]; then
-            echo "error condition: release-docker must include either release-arch-arm64 and/or arm64, both are false"
+            echo "error condition: release-docker must include either release-arch-arm64/amd64, both are false"
             exit -1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -899,12 +899,46 @@ jobs:
           gecho "docker_manifests:"
           gecho "  - name_template: ghcr.io/${{ github.repository }}:{{ .Tag }}"
           gecho "    image_templates:"
-          if [[ "${{ inputs.release-arch-amd64 }}" == "true" ]]; then
+          if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
             gecho "      -  ghcr.io/${{ github.repository }}:{{ .Tag }}-amd64"
           fi
           if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
             gecho "      -  ghcr.io/${{ github.repository }}:{{ .Tag }-arm64}"
           fi
+
+          if [[ "${{ inputs.release-docker-major }}" == "true" ]]; then
+            gecho "  - name_template: ghcr.io/${{ github.repository }}:v{{ .Major }}"
+            gecho "    image_templates:"
+            if [[ "${{ inputs.release-arch-amd64 }}" == "true" ]]; then
+                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}-amd64}"
+            fi
+            if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
+                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}-arm64}"
+            fi
+          fi
+
+          if [[ "${{ inputs.release-docker-minor }}" == "true" ]]; then
+            gecho "  - name_template: ghcr.io/${{ github.repository }}:v{{ .Major }}.{{ .Minor }}"
+            gecho "    image_templates:"
+            if [[ "${{ inputs.release-arch-amd64 }}" == "true" ]]; then
+                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}.{{ .Minor }}-amd64}"
+            fi
+            if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
+                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}.{{ .Minor }}-arm64}"
+            fi
+          fi
+
+          if [[ "${{ inputs.release-docker-latest }}" == "true" ]]; then
+            gecho "  - name_template: ghcr.io/${{ github.repository }}:latest"
+            gecho "    image_templates:"
+            if [[ "${{ inputs.release-arch-amd64 }}" == "true" ]]; then
+                      gecho "      - ghcr.io/${{ github.repository }}:latest-amd64}"
+            fi
+            if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
+                      gecho "      - ghcr.io/${{ github.repository }}:latest-arm64}"
+            fi
+          fi
+
 
       - name: Determine project license(s)
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,7 +800,7 @@ jobs:
           gecho "      - \"--build-arg=ARCH=amd64\""
           gecho "      - \"--build-arg=PLATFORM=linux/amd64\""
           gecho "    image_templates:"
-          gecho "      - ghcr.io/${{ github.repository }}:{{ .Tag }-amd64"
+          gecho "      - ghcr.io/${{ github.repository }}:{{ .Tag }}-amd64"
 
           if [[ "${{ inputs.release-docker-major }}" == "true" ]]; then
           gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}-amd64"
@@ -906,7 +906,7 @@ jobs:
             gecho "      -  ghcr.io/${{ github.repository }}:{{ .Tag }}-amd64"
           fi
           if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
-            gecho "      -  ghcr.io/${{ github.repository }}:{{ .Tag }-arm64"
+            gecho "      -  ghcr.io/${{ github.repository }}:{{ .Tag }}-arm64"
           fi
 
           if [[ "${{ inputs.release-docker-major }}" == "true" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,7 +857,7 @@ jobs:
           gecho "      - ghcr.io/${{ github.repository }}:{{ .Tag }}-arm64"
 
           if [[ "${{ inputs.release-docker-major }}" == "true" ]]; then
-          gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }-arm64"
+          gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}-arm64"
           fi
 
           if [[ "${{ inputs.release-docker-minor }}" == "true" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,6 +617,9 @@ jobs:
       needs.license.result       != 'failure'
     runs-on: [ ubuntu-latest ]
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@fcd3152d8ad392d0e9c14d3f0de40f0a88b8ca0e #v3.6.0
+
       - name: Install syft for sbom generation
         uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,7 +800,7 @@ jobs:
           gecho "      - \"--build-arg=ARCH=amd64\""
           gecho "      - \"--build-arg=PLATFORM=linux/amd64\""
           gecho "    image_templates:"
-          gecho "      - ghcr.io/${{ github.repository }}:{{ .Tag }-amd64}"
+          gecho "      - ghcr.io/${{ github.repository }}:{{ .Tag }-amd64"
 
           if [[ "${{ inputs.release-docker-major }}" == "true" ]]; then
           gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}-amd64"
@@ -857,7 +857,7 @@ jobs:
           gecho "      - ghcr.io/${{ github.repository }}:{{ .Tag }}-arm64"
 
           if [[ "${{ inputs.release-docker-major }}" == "true" ]]; then
-          gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }-arm64}"
+          gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }-arm64"
           fi
 
           if [[ "${{ inputs.release-docker-minor }}" == "true" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -906,17 +906,17 @@ jobs:
             gecho "      -  ghcr.io/${{ github.repository }}:{{ .Tag }}-amd64"
           fi
           if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
-            gecho "      -  ghcr.io/${{ github.repository }}:{{ .Tag }-arm64}"
+            gecho "      -  ghcr.io/${{ github.repository }}:{{ .Tag }-arm64"
           fi
 
           if [[ "${{ inputs.release-docker-major }}" == "true" ]]; then
             gecho "  - name_template: ghcr.io/${{ github.repository }}:v{{ .Major }}"
             gecho "    image_templates:"
             if [[ "${{ inputs.release-arch-amd64 }}" == "true" ]]; then
-                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}-amd64}"
+                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}-amd64"
             fi
             if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
-                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}-arm64}"
+                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}-arm64"
             fi
           fi
 
@@ -924,10 +924,10 @@ jobs:
             gecho "  - name_template: ghcr.io/${{ github.repository }}:v{{ .Major }}.{{ .Minor }}"
             gecho "    image_templates:"
             if [[ "${{ inputs.release-arch-amd64 }}" == "true" ]]; then
-                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}.{{ .Minor }}-amd64}"
+                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}.{{ .Minor }}-amd64"
             fi
             if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
-                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}.{{ .Minor }}-arm64}"
+                      gecho "      - ghcr.io/${{ github.repository }}:v{{ .Major }}.{{ .Minor }}-arm64"
             fi
           fi
 
@@ -935,10 +935,10 @@ jobs:
             gecho "  - name_template: ghcr.io/${{ github.repository }}:latest"
             gecho "    image_templates:"
             if [[ "${{ inputs.release-arch-amd64 }}" == "true" ]]; then
-                      gecho "      - ghcr.io/${{ github.repository }}:latest-amd64}"
+                      gecho "      - ghcr.io/${{ github.repository }}:latest-amd64"
             fi
             if [[ "${{ inputs.release-arch-arm64 }}" == "true" ]]; then
-                      gecho "      - ghcr.io/${{ github.repository }}:latest-arm64}"
+                      gecho "      - ghcr.io/${{ github.repository }}:latest-arm64"
             fi
           fi
 


### PR DESCRIPTION
# What is this PR out to accomplish?

This PR adds support for shipping `arm64` and `amd64` flavored docker images under the same tag by using docker manifests.

## Breaking Changes

This PR does break many of the current `xmidt-org` repos in their `dockerfile`. The configuration for downloading `spruce` is hardcoded to only pull `amd64` in many apps:

```
RUN mkdir -p /go/bin && \
    curl -L -o /go/bin/spruce https://github.com/geofffranks/spruce/releases/download/v1.29.0/spruce-linux-amd64 && \
    chmod +x /go/bin/spruce
```

The fix is twofold:
- Make the `curl` processor-architecture aware
- Update the version to one that supports `arm64`

In this example, I inlined the `go env GOARCH` command to get the runtime without having to be very explicit with pushing in build args. I also bumped the version to `v1.31.1` since it has `arm64` builds:

```
RUN mkdir -p /go/bin
RUN curl -Lo /go/bin/spruce https://github.com/geofffranks/spruce/releases/download/v1.31.1/spruce-linux-$(go env GOARCH)
RUN chmod +x /go/bin/spruce
RUN /go/bin/spruce --version
```

